### PR TITLE
Update VideoDecoder API usage.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "NaCl Multicast Streaming",
   "version": "0.1",
-  "minimum_chrome_version": "46",
+  "minimum_chrome_version": "47",
   "manifest_version": 2,
   "description": "Example of how to use the NaCl Multicast Streaming NaCl module.",
   "offline_enabled": true,

--- a/nacl/receiver/decoder.cc
+++ b/nacl/receiver/decoder.cc
@@ -28,7 +28,7 @@ Decoder::Decoder(pp::Instance* instance, int id,
 
   assert(!decoder_->is_null());
   decoder_->Initialize(graphics_3d, PP_VIDEOPROFILE_VP8_ANY,
-                       PP_HARDWAREACCELERATION_WITHFALLBACK,
+                       PP_HARDWAREACCELERATION_WITHFALLBACK, 0,
                        callback_factory_.NewCallback(&Decoder::InitializeDone));
 }
 


### PR DESCRIPTION
The VideoDecoder API changed to include a new parameter, so our code
must match in order to compile with newer versions of the SDK.

Signed-off-by: Rafael Antognolli rafael.antognolli@intel.com
